### PR TITLE
fix deprecation for ragged nested sequences

### DIFF
--- a/sklearn_json/classification.py
+++ b/sklearn_json/classification.py
@@ -541,9 +541,9 @@ def serialize_mlp(model):
 def deserialize_mlp(model_dict):
     model = MLPClassifier(**model_dict['params'])
 
-    model.coefs_ = np.array(model_dict['coefs_'])
+    model.coefs_ = np.array(model_dict['coefs_'], dtype=object)
     model.loss_ = model_dict['loss_']
-    model.intercepts_ = np.array(model_dict['intercepts_'])
+    model.intercepts_ = np.array(model_dict['intercepts_'], dtype=object)
     model.n_iter_ = model_dict['n_iter_']
     model.n_layers_ = model_dict['n_layers_']
     model.n_outputs_ = model_dict['n_outputs_']


### PR DESCRIPTION
Newer versions of numpy have the following deprecations:
```
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
```
This PR addresses those.