### PR TITLE
simple bugfix for new parameter name

### DIFF
--- a/sklearn_json/classification.py
+++ b/sklearn_json/classification.py
@@ -312,7 +312,7 @@ def serialize_decision_tree(model):
         'feature_importances_': model.feature_importances_.tolist(),
         'max_features_': model.max_features_,
         'n_classes_': int(model.n_classes_),
-        'n_features_': model.n_features_,
+        'n_features_': model.n_features_in_,
         'n_outputs_': model.n_outputs_,
         'tree_': tree,
         'classes_': model.classes_.tolist(),
@@ -335,7 +335,7 @@ def deserialize_decision_tree(model_dict):
     deserialized_model.classes_ = np.array(model_dict['classes_'])
     deserialized_model.max_features_ = model_dict['max_features_']
     deserialized_model.n_classes_ = model_dict['n_classes_']
-    deserialized_model.n_features_ = model_dict['n_features_']
+    deserialized_model.n_features_in_ = model_dict['n_features_']
     deserialized_model.n_outputs_ = model_dict['n_outputs_']
 
     tree = deserialize_tree(model_dict['tree_'], model_dict['n_features_'], model_dict['n_classes_'], model_dict['n_outputs_'])


### PR DESCRIPTION
Since scikit-learn 0.24 `n_features_` is called `n_features_in_`